### PR TITLE
fix for total time calculation on amazon music

### DIFF
--- a/json/amazon.json
+++ b/json/amazon.json
@@ -28,7 +28,7 @@
     "artist" : "$('.trackArtist a span').text()",
     "track" : "$('.trackTitle a span').text()",
     "currentTime" : "$('.songDuration.timeElapsed').text()",
-    "totalTime" : "$('.songDuration.timeRemaining').text()",
+    "remainingTime" : "$('.songDuration.timeRemaining').text()",
 
 "COMMENT_4" : "Finally, this block contains info on how to perform actions",
 


### PR DESCRIPTION
tracks from amazon music are not scrobbled, because "totalTime" selector is specified instead of "remainingTime"